### PR TITLE
Fix error in settings file

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,35 +1,35 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
-​
+
 repository:
   # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
   private: false
-​
+
   has_issues: false
   has_wiki: false
   has_projects: false
   has_downloads: false
-​
+
   default_branch: main
-​
+
   allow_auto_merge: true
   delete_branch_on_merge: true
   allow_forking: true
-​
+
 # Collaborators: give specific users access to this repository.
 # See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
 collaborators:
-​
+
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
   - name: all
-    permission: read
+    permission: pull
   - name: ce-admins
     permission: admin
   - name: ce-all
     permission: triage
   - name: content-managers
     permission: admin
-​
+
 branches:
   - name: main
     # https://docs.github.com/en/rest/reference/repos#update-branch-protection


### PR DESCRIPTION
`read` is not a valid value for team permission; however, `pull` is equivalent. This error was causing the bot that reads this file to throw an error and fail to update the remaining permissions.